### PR TITLE
F1673 team wip limit

### DIFF
--- a/soft_dev_kanban/__init__.py
+++ b/soft_dev_kanban/__init__.py
@@ -1,3 +1,4 @@
 # pylint: disable=relative-import
+import team
 import base_extension
 import project_extension

--- a/soft_dev_kanban/__openerp__.py
+++ b/soft_dev_kanban/__openerp__.py
@@ -12,6 +12,8 @@
     'website': '',
     'depends': ['project', 'hr'],
     'data': ['views/project_view.xml',
+             'views/users_view.xml',
+             'views/team_view.xml',
              'data/update_data.xml'],
     'demo': ['data/fixtures.xml'],
     'css': [],

--- a/soft_dev_kanban/base_extension.py
+++ b/soft_dev_kanban/base_extension.py
@@ -19,6 +19,8 @@ class ResUsersExtension(models.Model):
     throughput = fields.Float('Work Items per Day Average', default=0)
     wip_limit = fields.Integer('WIP Limit', default=0)
     date_last_wip_update = fields.Date('Last WIP update')
+    team_ids = fields.Many2many('sdk.user.team', 'team_users_rel', 'user_id',
+                                'team_id', 'Kanban Teams')
 
     @api.one
     def add_finished_item(self):

--- a/soft_dev_kanban/data/fixtures.xml
+++ b/soft_dev_kanban/data/fixtures.xml
@@ -49,10 +49,15 @@
             <field name="related_stage_id" ref="project_stage_release"/>
         </record>
 
-        <!-- Kanban User Team -->
+        <!-- Kanban User Teams -->
 
         <record id="sdk_user_team" model="sdk.user.team">
             <field name="name">SDK Demo Team</field>
+            <field name="wip_limit">0</field>
+        </record>
+
+        <record id="sdk_user_team_2" model="sdk.user.team">
+            <field name="name">SDK Demo Team 2</field>
             <field name="wip_limit">0</field>
         </record>
 

--- a/soft_dev_kanban/data/fixtures.xml
+++ b/soft_dev_kanban/data/fixtures.xml
@@ -49,7 +49,14 @@
             <field name="related_stage_id" ref="project_stage_release"/>
         </record>
 
-        <!-- Demo User -->
+        <!-- Kanban User Team -->
+
+        <record id="sdk_user_team" model="sdk.user.team">
+            <field name="name">SDK Demo Team</field>
+            <field name="wip_limit">0</field>
+        </record>
+
+        <!-- Demo Users -->
         <record id="sdk_partner_demo" model="res.partner">
             <field name="name">SDK Demo User</field>
             <field name="company_id" ref="base.main_company"/>
@@ -74,6 +81,34 @@
             <field name="throughput">2.0</field>
             <field name="wip_limit">2</field>
             <field name="date_last_wip_update">2000-10-10 00:00:00</field>
+            <field name="team_ids" eval="[(6, 0, [ref('sdk_user_team')])]"/>
+        </record>
+
+        <record id="sdk_partner_demo_2" model="res.partner">
+            <field name="name">SDK Demo User 2</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="customer" eval="False"/>
+            <field name="street">167 Wandsworth High St</field>
+            <field name="city">London</field>
+            <field name="zip">SW18 4JB</field>
+            <field name="country_id" ref="base.uk"/>
+        </record>
+
+        <record id="sdk_user_demo_2" model="res.users">
+            <field name="partner_id" ref="sdk_partner_demo_2"/>
+            <field name="login">sdk2</field>
+            <field name="password">sdk2</field>
+            <field name="signature">--Mr SDK</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="groups_id" eval="[(6,0,[ref('base.group_user'),
+            ref('base.group_partner_manager'),ref('base.group_sale_salesman'),
+            ref('project.group_project_manager')])]"/>
+            <field name="wi_finished">2</field>
+            <field name="total_days">10</field>
+            <field name="throughput">2.0</field>
+            <field name="wip_limit">0</field>
+            <field name="date_last_wip_update">2000-10-10 00:00:00</field>
+            <field name="team_ids" eval="[(6, 0, [ref('sdk_user_team')])]"/>
         </record>
 
         <!-- Demo Project and Tasks for integration tests -->

--- a/soft_dev_kanban/static/src/js/soft_dev_kanban.js
+++ b/soft_dev_kanban/static/src/js/soft_dev_kanban.js
@@ -33,6 +33,11 @@ openerp.soft_dev_kanban = function (instance) {
                                 self.do_warn('Warning', r);
                             }
                         });
+                        self.view.dataset.call('check_team_limit', [self.view.datarecord.id, change['stage_id']]).done(function (r) {
+                            if (r[0] != false){
+                                self.do_warn('Warning', r);
+                            }
+                        });
                     }
                 });
             }
@@ -52,6 +57,11 @@ openerp.soft_dev_kanban = function (instance) {
                     });
                     this.dataset.call('check_stage_limit', [new_group.value]).done(function (r){
                        if (r != false){
+                           self.do_warn('Warning', r);
+                       }
+                    });
+                    this.dataset.call('check_team_limit', [record.id, new_group.value]).done(function (r){
+                       if (r[0] != false){
                            self.do_warn('Warning', r);
                        }
                     });

--- a/soft_dev_kanban/team.py
+++ b/soft_dev_kanban/team.py
@@ -32,3 +32,14 @@ class KanbanUserTeam(models.Model):
         :rtype: int
         """
         return sum(self.user_ids.current_wip_items())
+
+    @api.one
+    def check_wip_limit(self):
+        """
+        Checks the WIP item limit for the team and returns a warning
+        message if it is overloaded.
+        """
+        if self.wip_limit:
+            if sum(self.current_wip_items()) > self.wip_limit:
+                return '{0} is overloaded'.format(self.name)
+        return False

--- a/soft_dev_kanban/team.py
+++ b/soft_dev_kanban/team.py
@@ -16,11 +16,22 @@ class KanbanUserTeam(models.Model):
     name = fields.Char('Name')
     user_ids = fields.Many2many('res.users', 'team_users_rel', 'team_id',
                                 'user_id', 'Team Members')
-    wi_finished = fields.Integer('Work Items Finished Today', default=0)
-    total_days = fields.Integer('Total Days Processed', default=0)
-    throughput = fields.Float('Work Items per Day Average', default=0)
+    throughput = fields.Float(
+        string='Throughput', compute='_compute_throughput',
+        store=False, readonly=True)
     wip_limit = fields.Integer('WIP Limit', default=0)
-    date_last_wip_update = fields.Date('Last WIP update')
+
+    @api.one
+    def _compute_throughput(self):
+        """
+        Computes the average throughput of the team.
+
+        :returns: work items per day on average
+        :rtype: float
+        """
+        if not self.user_ids:
+            return 0
+        return sum([u.throughput for u in self.user_ids])/len(self.user_ids)
 
     @api.one
     def current_wip_items(self):

--- a/soft_dev_kanban/team.py
+++ b/soft_dev_kanban/team.py
@@ -2,10 +2,7 @@
 `team.py` adds the concept of User Team for the Kanban management.
 """
 
-from openerp.models import Environment
-from openerp import models, fields, api
-from datetime import datetime as dt
-from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT as dtf
+from openerp import models, fields
 
 
 class KanbanUserTeam(models.Model):

--- a/soft_dev_kanban/team.py
+++ b/soft_dev_kanban/team.py
@@ -1,0 +1,26 @@
+"""
+`team.py` adds the concept of User Team for the Kanban management.
+"""
+
+from openerp.models import Environment
+from openerp import models, fields, api
+from datetime import datetime as dt
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT as dtf
+
+
+class KanbanUserTeam(models.Model):
+    """
+    Represents a Kanban user team which groups users together in order to
+    manage metrics and limits for the team as a whole, instead of using
+    just individuals.
+    """
+    _name = 'sdk.user.team'
+
+    name = fields.Char('Name')
+    user_ids = fields.Many2many('res.users', 'team_users_rel', 'team_id',
+                                'user_id', 'Team Members')
+    wi_finished = fields.Integer('Work Items Finished Today', default=0)
+    total_days = fields.Integer('Total Days Processed', default=0)
+    throughput = fields.Float('Work Items per Day Average', default=0)
+    wip_limit = fields.Integer('WIP Limit', default=0)
+    date_last_wip_update = fields.Date('Last WIP update')

--- a/soft_dev_kanban/team.py
+++ b/soft_dev_kanban/team.py
@@ -2,7 +2,7 @@
 `team.py` adds the concept of User Team for the Kanban management.
 """
 
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class KanbanUserTeam(models.Model):
@@ -21,3 +21,14 @@ class KanbanUserTeam(models.Model):
     throughput = fields.Float('Work Items per Day Average', default=0)
     wip_limit = fields.Integer('WIP Limit', default=0)
     date_last_wip_update = fields.Date('Last WIP update')
+
+    @api.one
+    def current_wip_items(self):
+        """
+        Computes the current number of work in progress items of the
+        team.
+
+        :returns: number of work items
+        :rtype: int
+        """
+        return sum(self.user_ids.current_wip_items())

--- a/soft_dev_kanban/tests/__init__.py
+++ b/soft_dev_kanban/tests/__init__.py
@@ -7,3 +7,4 @@ import test_users_wip_management
 import test_task_wip_management
 import test_stage_related_stage
 import test_stage_wip_limit
+import test_team_wip_limit

--- a/soft_dev_kanban/tests/test_stage_wip_limit.py
+++ b/soft_dev_kanban/tests/test_stage_wip_limit.py
@@ -66,7 +66,7 @@ class TestStageWipLimit(common.SingleTransactionCase):
         self.task.stage_id = self.other.id
         self.assertEqual(self.other.current_wip_items()[0], 1)
 
-    def test_08_current_wip_items_count_tasks_related_to_stage(self):
+    def test_08_current_wip_items_count_tasks_related_to_stage_queues(self):
         self.task.stage_id = self.backlog.id
         self.assertEqual(self.other.current_wip_items()[0], 0)
         self.task.stage_id = self.rel_ready.id

--- a/soft_dev_kanban/tests/test_team_wip_limit.py
+++ b/soft_dev_kanban/tests/test_team_wip_limit.py
@@ -29,9 +29,16 @@ class TestTeamWipLimit(common.SingleTransactionCase):
         cls.user = cls.user_model.search([['name', '=', 'SDK Demo User']])
         cls.user2 = cls.user_model.search([['name', '=', 'SDK Demo User 2']])
         cls.team = cls.team_model.search([['name', '=', 'SDK Demo Team']])
+        cls.team2 = cls.team_model.search([['name', '=', 'SDK Demo Team 2']])
         cls.task = cls.task_model.search(
             [['name', '=', 'Refactor Tests Code']])
         cls.task2 = cls.task_model.search([['name', '=', 'WIP Management']])
+
+    def test_00_compute_throughput_return_average_user_throughput(self):
+        self.team2._compute_throughput()
+        self.assertEqual(self.team2.throughput, 0)
+        self.team._compute_throughput()
+        self.assertEqual(self.team.throughput, 0)
 
     def test_01_current_wip_items_count_developer_items_on_dev_stage(self):
         self.task.stage_id = self.dev.id
@@ -87,7 +94,7 @@ class TestTeamWipLimit(common.SingleTransactionCase):
         self.task2.stage_id = self.queue.id
         self.assertEqual(self.team.check_wip_limit()[0],
                          'SDK Demo Team is overloaded')
-        self.assertEqual(self.task.check_team_limit(self.input.id)[0],
+        self.assertEqual(self.task.check_team_limit(self.queue.id)[0],
                          'SDK Demo Team is overloaded')
 
     def test_09_check_wip_limit_review_return_warning_if_overloaded(self):
@@ -95,7 +102,7 @@ class TestTeamWipLimit(common.SingleTransactionCase):
         self.task2.stage_id = self.testready.id
         self.assertEqual(self.team.check_wip_limit()[0],
                          'SDK Demo Team is overloaded')
-        self.assertEqual(self.task.check_team_limit(self.input.id)[0],
+        self.assertEqual(self.task.check_team_limit(self.testready.id)[0],
                          'SDK Demo Team is overloaded')
 
     def test_10_check_wip_limit_no_warning_if_limit_is_0(self):

--- a/soft_dev_kanban/tests/test_team_wip_limit.py
+++ b/soft_dev_kanban/tests/test_team_wip_limit.py
@@ -1,5 +1,4 @@
 from openerp.tests import common
-from openerp.models import except_orm
 
 
 class TestTeamWipLimit(common.SingleTransactionCase):

--- a/soft_dev_kanban/tests/test_team_wip_limit.py
+++ b/soft_dev_kanban/tests/test_team_wip_limit.py
@@ -75,14 +75,30 @@ class TestTeamWipLimit(common.SingleTransactionCase):
         self.task2.stage_id = self.input.id
         self.assertEqual(self.team.current_wip_items()[0], 2)
 
-    def test_07_check_wip_limit_return_warning_if_overloaded(self):
+    def test_07_check_wip_limit_analysis_return_warning_if_overloaded(self):
         self.team.wip_limit = 1
         self.assertEqual(self.team.check_wip_limit()[0],
                          'SDK Demo Team is overloaded')
         self.assertEqual(self.task.check_team_limit(self.input.id)[0],
                          'SDK Demo Team is overloaded')
 
-    def test_08_check_wip_limit_no_warning_if_limit_is_0(self):
+    def test_08_check_wip_limit_dev_return_warning_if_overloaded(self):
+        self.task.stage_id = self.queue.id
+        self.task2.stage_id = self.queue.id
+        self.assertEqual(self.team.check_wip_limit()[0],
+                         'SDK Demo Team is overloaded')
+        self.assertEqual(self.task.check_team_limit(self.input.id)[0],
+                         'SDK Demo Team is overloaded')
+
+    def test_09_check_wip_limit_review_return_warning_if_overloaded(self):
+        self.task.stage_id = self.testready.id
+        self.task2.stage_id = self.testready.id
+        self.assertEqual(self.team.check_wip_limit()[0],
+                         'SDK Demo Team is overloaded')
+        self.assertEqual(self.task.check_team_limit(self.input.id)[0],
+                         'SDK Demo Team is overloaded')
+
+    def test_10_check_wip_limit_no_warning_if_limit_is_0(self):
         self.team.wip_limit = 0
         self.assertFalse(self.team.check_wip_limit()[0])
         self.assertFalse(self.task.check_team_limit(self.input.id)[0])

--- a/soft_dev_kanban/tests/test_team_wip_limit.py
+++ b/soft_dev_kanban/tests/test_team_wip_limit.py
@@ -1,0 +1,37 @@
+from openerp.tests import common
+from openerp.models import except_orm
+
+
+class TestTeamWipLimit(common.SingleTransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestTeamWipLimit, cls).setUpClass()
+        cls.task_model = cls.env['project.task']
+        cls.user_model = cls.env['res.users']
+        cls.team_model = cls.env['sdk.user.team']
+        cls.stage_model = cls.env['project.task.type']
+
+        cls.backlog = cls.stage_model.search([['name', '=', 'Backlog']])
+        cls.queue = cls.stage_model.search(
+            [['name', '=', 'Development Ready']])
+        cls.input = cls.stage_model.search(
+            [['name', '=', 'Input Queue']])
+        cls.testready = cls.stage_model.search(
+            [['name', '=', 'Test Ready']])
+        cls.rel_ready = cls.stage_model.search(
+            [['name', '=', 'Release Ready']])
+        cls.analysis = cls.stage_model.search([['name', '=', 'Analysis']])
+        cls.dev = cls.stage_model.search([['name', '=', 'Development']])
+        cls.review = cls.stage_model.search([['name', '=', 'Testing']])
+        cls.done = cls.stage_model.search([['name', '=', 'Done']])
+        cls.other = cls.stage_model.search([['name', '=', 'Release']])
+
+        cls.user = cls.user_model.search([['name', '=', 'SDK Demo User']])
+        cls.user2 = cls.user_model.search([['name', '=', 'SDK Demo User 2']])
+        cls.team = cls.team_model.search([['name', '=', 'SDK Demo Team']])
+        cls.task = cls.task_model.search(
+            [['name', '=', 'Refactor Tests Code']])
+        cls.task2 = cls.task_model.search([['name', '=', 'WIP Management']])
+
+    # def test_01_write_wip_limit_raises_if_backlog(self):

--- a/soft_dev_kanban/tests/test_team_wip_limit.py
+++ b/soft_dev_kanban/tests/test_team_wip_limit.py
@@ -33,4 +33,44 @@ class TestTeamWipLimit(common.SingleTransactionCase):
             [['name', '=', 'Refactor Tests Code']])
         cls.task2 = cls.task_model.search([['name', '=', 'WIP Management']])
 
-    # def test_01_write_wip_limit_raises_if_backlog(self):
+    def test_01_current_wip_items_count_developer_items_on_dev_stage(self):
+        self.task.stage_id = self.dev.id
+        self.task2.stage_id = self.dev.id
+        self.assertEqual(self.team.current_wip_items()[0], 0)
+        self.task.user_id = self.user.id
+        self.assertEqual(self.team.current_wip_items()[0], 1)
+        self.task2.user_id = self.user2.id
+        self.assertEqual(self.team.current_wip_items()[0], 2)
+
+    def test_02_current_wip_items_count_developer_items_on_dev_queue(self):
+        self.task.stage_id = self.queue.id
+        self.task2.stage_id = self.queue.id
+        self.assertEqual(self.team.current_wip_items()[0], 2)
+
+    def test_03_current_wip_items_count_reviewer_items_on_review_stage(self):
+        self.task.stage_id = self.review.id
+        self.task2.stage_id = self.review.id
+        self.assertEqual(self.team.current_wip_items()[0], 0)
+        self.task.reviewer_id = self.user.id
+        self.assertEqual(self.team.current_wip_items()[0], 1)
+        self.task2.reviewer_id = self.user2.id
+        self.assertEqual(self.team.current_wip_items()[0], 2)
+
+    def test_04_current_wip_items_count_reviewer_items_on_review_queue(self):
+        self.task.stage_id = self.testready.id
+        self.task2.stage_id = self.testready.id
+        self.assertEqual(self.team.current_wip_items()[0], 2)
+
+    def test_05_current_wip_items_count_analyst_items_on_analysis_stage(self):
+        self.task.stage_id = self.analysis.id
+        self.task2.stage_id = self.analysis.id
+        self.assertEqual(self.team.current_wip_items()[0], 0)
+        self.task.analyst_id = self.user.id
+        self.assertEqual(self.team.current_wip_items()[0], 1)
+        self.task2.analyst_id = self.user2.id
+        self.assertEqual(self.team.current_wip_items()[0], 2)
+
+    def test_06_current_wip_items_count_analyst_items_on_analysis_queue(self):
+        self.task.stage_id = self.input.id
+        self.task2.stage_id = self.input.id
+        self.assertEqual(self.team.current_wip_items()[0], 2)

--- a/soft_dev_kanban/tests/test_team_wip_limit.py
+++ b/soft_dev_kanban/tests/test_team_wip_limit.py
@@ -74,3 +74,15 @@ class TestTeamWipLimit(common.SingleTransactionCase):
         self.task.stage_id = self.input.id
         self.task2.stage_id = self.input.id
         self.assertEqual(self.team.current_wip_items()[0], 2)
+
+    def test_07_check_wip_limit_return_warning_if_overloaded(self):
+        self.team.wip_limit = 1
+        self.assertEqual(self.team.check_wip_limit()[0],
+                         'SDK Demo Team is overloaded')
+        self.assertEqual(self.task.check_team_limit(self.input.id)[0],
+                         'SDK Demo Team is overloaded')
+
+    def test_08_check_wip_limit_no_warning_if_limit_is_0(self):
+        self.team.wip_limit = 0
+        self.assertFalse(self.team.check_wip_limit()[0])
+        self.assertFalse(self.task.check_team_limit(self.input.id)[0])

--- a/soft_dev_kanban/views/team_view.xml
+++ b/soft_dev_kanban/views/team_view.xml
@@ -1,0 +1,67 @@
+<openerp>
+    <data>
+        <record id="view_team_form" model="ir.ui.view">
+            <field name="name">view.user.team.form</field>
+            <field name="model">sdk.user.team</field>
+            <field name="arch" type="xml">
+                <form string="Team">
+                    <sheet>
+                        <div class="oe_title">
+                            <label for="name" class="oe_edit_only"/>
+                            <h1><field name="name"/></h1>
+                        </div>
+                        <group>
+                            <field name="throughput" readonly="1"/>
+                            <field name="wip_limit"/>
+                        </group>
+                        <notebook colspan="4">
+                            <page string="Team Members">
+                                <group col="4">
+                                    <field name="user_ids" nolabel="1">
+                                        <tree>
+                                            <field name="name"/>
+                                        </tree>
+                                    </field>
+                                </group>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_team_tree" model="ir.ui.view">
+            <field name="name">view.user.team.tree</field>
+            <field name="model">sdk.user.team</field>
+            <field name="arch" type="xml">
+                <tree string="Teams">
+                    <field name="name"/>
+                    <field name="throughput"/>
+                    <field name="wip_limit"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_team_search" model="ir.ui.view">
+            <field name="name">view.user.team.search</field>
+            <field name="model">sdk.user.team</field>
+            <field name="arch" type="xml">
+                <search string="Teams">
+                    <field name="name" string="Team"/>
+                    <field name="user_ids" string="Team Member"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_user_teams" model="ir.actions.act_window">
+            <field name="name">Kanban Teams</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">sdk.user.team</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="view_team_tree"/>
+            <field name="search_view_id" ref="view_team_search"/>
+        </record>
+
+        <menuitem action="action_user_teams" id="menu_action_view_teams" parent="base.menu_definitions" sequence="50"/>
+    </data>
+</openerp>

--- a/soft_dev_kanban/views/users_view.xml
+++ b/soft_dev_kanban/views/users_view.xml
@@ -1,0 +1,20 @@
+<openerp>
+    <data>
+        <record id="res_users_view_form_ext" model="ir.ui.view">
+            <field name="name">res.users.form.ext</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Preferences']" position="after">
+                    <page string="Kanban Settings">
+                        <group>
+                            <field name="throughput" readonly="1"/>
+                            <field name="wip_limit"/>
+                            <field name="team_ids" widget="many2many_tags"/>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
- [x] Add team to users so there can be a user grouping.
- [x] Add wip_limit to teams so wip can be managed on team level.
- [x] Add check_wip_limit to teams to check if the current amount of work items is greater than the limit.
- [x] Add current_wip_items to teams to count work items of users in the team.
